### PR TITLE
About page fixed

### DIFF
--- a/about/index.md
+++ b/about/index.md
@@ -5,7 +5,7 @@ title: About
 navigation: true
 logo: 'assets/images/ghost.png'
 class: page-template
-subclass: 'post page'
+subclass: 'post'
 ---
 
 Rotaract Club of IIT Jodhpur was established in the year of 2018 with the motive of serving the society. Our team frequently organizes events like, free health checkups, cloth distribution at the campus of IIT Jodhpur.


### PR DESCRIPTION
The about page wasn't rendering properly on browsers.
After this PR, it will be fixed. Refer the screenshots below.
**Before**
![Screenshot from 2019-08-11 15-17-20](https://user-images.githubusercontent.com/36567889/62832422-4a804480-bc4b-11e9-9c77-9520df9d75ba.png)
**After**
![Screenshot from 2019-08-11 15-19-04](https://user-images.githubusercontent.com/36567889/62832430-5ff56e80-bc4b-11e9-94a5-e7869904931b.png)
